### PR TITLE
Various bug fixes for ``yaw.core.config``

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit = src/yaw/examples/*
+
+[report]
+exclude_lines =
+    # Skip any pass lines such as may be used for @abstractmethod
+    pass
+    # Have to re-enable the standard pragma
+    pragma: no cover

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,10 +8,18 @@ Version 2.5.3
 - Emit warnings instead of sending to the python logging interface where they
   might be unnoticed.
 - Added unittest for ``yaw.core.config``.
+- Added missing unittest for ``yaw.core.cosmology``.
+- Deprecated the ``Configuration.plot_scales`` method.
 
 .. rubric:: Bug fixes
 
 - Added missing default values when creating binning configurations.
+- Added missing checks for input parameters of configuration related classes.
+- Made the behaviour of ``Configuration.modify`` for different binning related
+  parameters consistent.
+- Fixed the ``ResamplingConfig.n_patches`` return values.
+- Corrected the parameters returned by ``ResamplingConfig.to_dict``.
+- Various other minor bug fixes in ``yaw.core.config``.
 
 
 Version 2.5.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@ Change log
 ==========
 
 
+Version 2.5.3
+-------------
+
+- Emit warnings instead of sending to the python logging interface where they
+  might be unnoticed.
+- Added unittest for ``yaw.core.config``.
+
+.. rubric:: Bug fixes
+
+- Added missing default values when creating binning configurations.
+
+
 Version 2.5.2
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,15 @@ The yet_another_wizz package can be installed directly with pip::
 
     pip install yet_another_wizz
 
-This will install the python library ``yaw``. There also exists a separate
-command line tool called *yet_another_wizz_cli* (``yaw_cli``) that is available
-at PyPI and `github <https://github.com/jlvdb/yet_another_wizz_cli>`_. To
-install it alongside the python library, type::
+This will install the python library ``yaw``.
+
+Commandline tool
+~~~~~~~~~~~~~~~~
+
+There also exists a separate command line tool called
+`yet_another_wizz_cli <https://github.com/jlvdb/yet_another_wizz_cli>`_
+(``yaw_cli``) that is available at PyPI and github. To install it alongside the
+python library, type::
 
     pip install yet_another_wizz[cli]
 

--- a/src/yaw/__init__.py
+++ b/src/yaw/__init__.py
@@ -37,7 +37,7 @@ from yaw.deprecated import (
 from yaw.randoms import UniformRandoms
 from yaw.redshifts import HistData, RedshiftData
 
-__version__ = "2.5.2"
+__version__ = "2.5.3"
 
 __all__ = [
     "NewCatalog",

--- a/src/yaw/config/backend.py
+++ b/src/yaw/config/backend.py
@@ -63,12 +63,16 @@ class BackendConfig(DictRepresentation):
     def get_threads(self, max=None) -> int:
         """Get the number of threads for parallel processing.
 
-        The value is capped at the number of logical cores available.
+        The value is capped at an optional maximum value.
+
+        Args:
+            max (:obj:`int`, optional):
+                Maximum number to return.
+
+        Returns:
+            :obj:`int`
         """
-        if self.thread_num is None:
-            thread_num = os.cpu_count()
-        else:
-            thread_num = self.thread_num
+        thread_num = self.thread_num
         if max is not None:
             if max < 1:
                 raise ValueError("'max' must be positive")

--- a/src/yaw/config/binning.py
+++ b/src/yaw/config/binning.py
@@ -193,9 +193,9 @@ class AutoBinningConfig(BaseBinningConfig):
         return cls(zbins, method)
 
     def __eq__(self, other: ManualBinningConfig) -> bool:
-        if not array_equal(self.zbins, other.zbins):
-            return False
         if self.method != other.method:
+            return False
+        if not array_equal(self.zbins, other.zbins):
             return False
         return True
 

--- a/src/yaw/config/binning.py
+++ b/src/yaw/config/binning.py
@@ -223,7 +223,8 @@ class AutoBinningConfig(BaseBinningConfig):
 
 
 def make_binning_config(
-    cosmology: TypeCosmology | str | None,
+    *,
+    cosmology: TypeCosmology | str | None = None,
     zmin: float | None = None,
     zmax: float | None = None,
     zbin_num: int = DEFAULT.AutoBinning.zbin_num,

--- a/src/yaw/config/binning.py
+++ b/src/yaw/config/binning.py
@@ -90,7 +90,9 @@ class ManualBinningConfig(BaseBinningConfig):
 
     @classmethod
     def from_dict(cls, the_dict: dict[str, Any], **kwargs) -> ManualBinningConfig:
-        return cls(np.asarray(the_dict["zbins"]))
+        new_dict = {key: val for key, val in the_dict.items()}
+        zbins = new_dict.pop("zbins")
+        return cls(np.asarray(zbins), **new_dict)
 
     def to_dict(self) -> dict[str, Any]:
         return dict(method=self.method, zbins=self.zbins.tolist())

--- a/src/yaw/config/binning.py
+++ b/src/yaw/config/binning.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -18,9 +18,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from numpy.typing import NDArray
 
 __all__ = ["AutoBinningConfig", "ManualBinningConfig", "make_binning_config"]
-
-
-logger = logging.getLogger(__name__)
 
 
 class BaseBinningConfig(DictRepresentation):
@@ -247,7 +244,7 @@ def make_binning_config(
         raise ConfigError("either 'zbins' or 'zmin' and 'zmax' are required")
     elif all(auto_args_set):
         if all(manual_args_set):
-            logger.warning(
+            warnings.warn(
                 "'zbins' set but ignored since 'zmin' and 'zmax' are provided"
             )
         return AutoBinningConfig.generate(

--- a/src/yaw/config/config.py
+++ b/src/yaw/config/config.py
@@ -309,7 +309,7 @@ class Configuration(DictRepresentation):
             utils.parse_section_error(e, "scales")
         try:
             binning_conf = config.pop("binning")
-            binning = make_binning_config(cosmology, **binning_conf)
+            binning = make_binning_config(cosmology=cosmology, **binning_conf)
         except (TypeError, KeyError) as e:
             utils.parse_section_error(e, "binning")
         # parse the optional subgroups

--- a/src/yaw/config/config.py
+++ b/src/yaw/config/config.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, get_args
 
 import numpy as np
 import yaml
+from deprecated import deprecated
 
 from yaw.config import OPTIONS
 from yaw.config import default as DEFAULT
@@ -252,11 +253,16 @@ class Configuration(DictRepresentation):
             config["backend"]["rbin_slop"] = rbin_slop
         return self.__class__.from_dict(config)
 
+    @deprecated(reason="no longer maintained", version="2.5.3")
     def plot_scales(
         self, catalog: BaseCatalog, log: bool = True, legend: bool = True
-    ) -> Figure:
+    ) -> Figure:  # pragma: no cover
         """Plot the configured correlation scales at different redshifts in
-        comparison to the size of patches in a data catalogue."""
+        comparison to the size of patches in a data catalogue.
+
+        .. deprecated:: 2.5.3
+            No longer maintained.
+        """
         import matplotlib.pyplot as plt
 
         fig, ax_scale = plt.subplots(1, 1)

--- a/src/yaw/config/config.py
+++ b/src/yaw/config/config.py
@@ -15,7 +15,6 @@ from yaw.config.binning import (
     AutoBinningConfig,
     ManualBinningConfig,
     make_binning_config,
-    warn_binning_args_ignored,
 )
 from yaw.config.scales import ScalesConfig
 from yaw.core.abc import DictRepresentation
@@ -235,17 +234,15 @@ class Configuration(DictRepresentation):
             config["scales"]["rbin_num"] = rbin_num
         # AutoBinningConfig /  ManualBinningConfig
         if zbins is not DEFAULT.NotSet:
-            warn_binning_args_ignored(zmin, zmax, zbin_num)
             config["binning"]["zbins"] = zbins
-        else:
-            if zmin is not DEFAULT.NotSet:
-                config["binning"]["zmin"] = zmin
-            if zmax is not DEFAULT.NotSet:
-                config["binning"]["zmax"] = zmax
-            if zbin_num is not DEFAULT.NotSet:
-                config["binning"]["zbin_num"] = zbin_num
-            if method is not DEFAULT.NotSet:
-                config["binning"]["method"] = method
+        if zmin is not DEFAULT.NotSet:
+            config["binning"]["zmin"] = zmin
+        if zmax is not DEFAULT.NotSet:
+            config["binning"]["zmax"] = zmax
+        if zbin_num is not DEFAULT.NotSet:
+            config["binning"]["zbin_num"] = zbin_num
+        if method is not DEFAULT.NotSet:
+            config["binning"]["method"] = method
         # BackendConfig
         if thread_num is not DEFAULT.NotSet:
             config["backend"]["thread_num"] = thread_num

--- a/src/yaw/config/resampling.py
+++ b/src/yaw/config/resampling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -73,8 +73,10 @@ class ResamplingConfig(DictRepresentation):
         """
         if self._resampling_idx is None:
             return None
-        else:
+        elif self.method == "bootstrap":
             return self._resampling_idx.shape[1]
+        else:
+            return self._resampling_idx.shape[0]
 
     def _generate_bootstrap(self, n_patches: int) -> NDArray[np.int_]:
         """Generate samples for the bootstrap resampling method.
@@ -134,6 +136,12 @@ class ResamplingConfig(DictRepresentation):
 
     def to_dict(self) -> dict[str, Any]:
         if self.method == "jackknife":
-            return dict(method=self.method, crosspatch=self.crosspatch)
+            return dict(
+                method=self.method,
+                crosspatch=self.crosspatch,
+                global_norm=self.global_norm,
+            )
         else:
-            return super().to_dict()
+            the_dict = asdict(self)
+            the_dict.pop("_resampling_idx")
+            return the_dict

--- a/src/yaw/config/scales.py
+++ b/src/yaw/config/scales.py
@@ -37,10 +37,10 @@ class ScalesConfig(DictRepresentation):
     can be controlled by setting the number of bins.
 
     Args:
-        rmin (:obj:`float`, :obj:`Sequence[float]`):
+        rmin (:obj:`float`, :obj:`list[float]`):
             Single or multiple lower scale limits in kpc (angular diameter
             distance).
-        rmax (:obj:`float`, :obj:`Sequence[float]`):
+        rmax (:obj:`float`, :obj:`list[float]`):
             Single or multiple upper scale limits in kpc (angular diameter
             distance).
         rweight (:obj:`float`, optional):
@@ -50,7 +50,7 @@ class ScalesConfig(DictRepresentation):
             by separation.
     """
 
-    rmin: Sequence[float] | float = field(
+    rmin: list[float] | float = field(
         metadata=Parameter(
             type=float,
             nargs="*",
@@ -59,7 +59,7 @@ class ScalesConfig(DictRepresentation):
         )
     )
     """Lower scale limit(s) in kpc (angular diameter distance)."""
-    rmax: Sequence[float] | float = field(
+    rmax: list[float] | float = field(
         metadata=Parameter(
             type=float,
             nargs="*",

--- a/src/yaw/config/utils.py
+++ b/src/yaw/config/utils.py
@@ -67,7 +67,10 @@ def parse_section_error(
     entirely missing subsection in the configuration.
     """
     msg = exception.args[0]
-    item = msg.split("'")[1]
+    try:
+        item = msg.split("'")[1]
+    except IndexError:
+        item = msg
     if isinstance(exception, TypeError):
         if "__init__() got an unexpected keyword argument" in msg:
             raise reraise(

--- a/src/yaw/config/utils.py
+++ b/src/yaw/config/utils.py
@@ -4,7 +4,7 @@ from typing import NoReturn, get_args
 
 import astropy.cosmology
 
-from yaw.core.cosmology import TypeCosmology, get_default_cosmology
+from yaw.core.cosmology import CustomCosmology, TypeCosmology, get_default_cosmology
 
 __all__ = [
     "cosmology_to_yaml",
@@ -23,8 +23,10 @@ def cosmology_to_yaml(cosmology: TypeCosmology) -> str:
 
     If it is one of the names :obj:`astropy` cosmologies, returns the name,
     otherwise raises an :exc:`ConfigError`."""
-    if not isinstance(cosmology, astropy.cosmology.FLRW):
+    if isinstance(cosmology, CustomCosmology):
         raise ConfigError("cannot serialise custom cosmoligies to YAML")
+    elif not isinstance(cosmology, astropy.cosmology.FLRW):
+        raise TypeError(f"invalid type '{type(cosmology)}' for cosmology")
     if cosmology.name not in astropy.cosmology.available:
         raise ConfigError("can only serialise predefined astropy cosmologies to YAML")
     return cosmology.name
@@ -52,7 +54,7 @@ def parse_cosmology(cosmology: TypeCosmology | str | None) -> TypeCosmology:
     elif isinstance(cosmology, str):
         cosmology = yaml_to_cosmology(cosmology)
     elif not isinstance(cosmology, get_args(TypeCosmology)):
-        which = ", ".join(get_args(TypeCosmology))
+        which = ", ".join(str(c) for c in get_args(TypeCosmology))
         raise ConfigError(f"'cosmology' must be instance of: {which}")
     return cosmology
 

--- a/src/yaw/config/utils.py
+++ b/src/yaw/config/utils.py
@@ -68,20 +68,21 @@ def parse_section_error(
     Covered cases are undefined key names, missing required key names or
     entirely missing subsection in the configuration.
     """
-    msg = exception.args[0]
-    try:
-        item = msg.split("'")[1]
-    except IndexError:
-        item = msg
-    if isinstance(exception, TypeError):
-        if "__init__() got an unexpected keyword argument" in msg:
-            raise reraise(
-                f"encountered unknown option '{item}' in section '{section}'"
-            ) from exception
-        elif "missing" in msg:
-            raise reraise(
-                f"missing option '{item}' in section '{section}'"
-            ) from exception
-    elif isinstance(exception, KeyError):
-        raise reraise(f"missing section '{section}'") from exception
+    if len(exception.args) > 0:
+        msg = exception.args[0]
+        try:
+            item = msg.split("'")[1]
+        except IndexError:
+            item = msg
+        if isinstance(exception, TypeError):
+            if "got an unexpected keyword argument" in msg:
+                raise reraise(
+                    f"encountered unknown option '{item}' in section '{section}'"
+                ) from exception
+            elif "missing" in msg:
+                raise reraise(
+                    f"missing option '{item}' in section '{section}'"
+                ) from exception
+        elif isinstance(exception, KeyError):
+            raise reraise(f"missing section '{section}'") from exception
     raise

--- a/src/yaw/core/abc.py
+++ b/src/yaw/core/abc.py
@@ -53,7 +53,7 @@ class PatchedQuantity(ABC):
         Returns:
             :obj:`yaw.core.containers.Indexer`
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def concatenate_patches(self: _Tpatched, *data: _Tpatched) -> _Tpatched:
@@ -77,7 +77,7 @@ class PatchedQuantity(ABC):
         Returns:
             New instance of this container with combined data.
         """
-        raise NotImplementedError
+        pass
 
 
 _Tbinned = TypeVar("_Tbinned", bound="BinnedQuantity")
@@ -86,13 +86,14 @@ _Tbinned = TypeVar("_Tbinned", bound="BinnedQuantity")
 class BinnedQuantity(ABC):
     """Base class for an object that has data organised in redshift bins."""
 
+    @abstractmethod
     def get_binning(self) -> IntervalIndex:
         """Get the underlying, exact redshift bin intervals.
 
         Returns:
             :obj:`pandas.IntervalIndex`
         """
-        raise NotImplementedError
+        pass
 
     def __repr__(self) -> str:
         name = self.__class__.__name__
@@ -144,7 +145,7 @@ class BinnedQuantity(ABC):
         Returns:
             :obj:`yaw.core.containers.Indexer`
         """
-        raise NotImplementedError
+        pass
 
     def is_compatible(self: _Tbinned, other: _Tbinned, require: bool = False) -> bool:
         """Check whether this instance is compatible with another instance.
@@ -197,7 +198,7 @@ class BinnedQuantity(ABC):
         Returns:
             New instance of this container with combined data.
         """
-        raise NotImplementedError
+        pass
 
 
 def concatenate_bin_edges(*patched: BinnedQuantity) -> IntervalIndex:
@@ -237,7 +238,7 @@ class HDFSerializable(ABC):
         Returns:
             :obj:`HDFSerializablep`
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def to_hdf(self, dest: h5py.Group) -> None:
@@ -247,7 +248,7 @@ class HDFSerializable(ABC):
             dest (:obj:`h5py.Group`):
                 Group in which the serialised data structures are created.
         """
-        raise NotImplementedError
+        pass
 
     @classmethod
     def from_file(cls: Type[_Thdf], path: TypePathStr) -> _Thdf:

--- a/src/yaw/core/cosmology.py
+++ b/src/yaw/core/cosmology.py
@@ -56,7 +56,7 @@ class CustomCosmology(ABC):
             :obj:`astropy.units.Quantity`:
                 Comoving distance in Mpc to each input redshift.
         """
-        NotImplemented
+        pass
 
     @abstractmethod
     def comoving_transverse_distance(self, z: ArrayLike) -> ArrayLike:
@@ -75,7 +75,7 @@ class CustomCosmology(ABC):
             :obj:`astropy.units.Quantity`:
                 Comoving transverse distance in Mpc at each input redshift.
         """
-        NotImplemented
+        pass
 
 
 TypeCosmology: TypeAlias = Union[FLRW, CustomCosmology]

--- a/src/yaw/core/logging.py
+++ b/src/yaw/core/logging.py
@@ -3,55 +3,11 @@
 
 from __future__ import annotations
 
-import logging
-import warnings
 from datetime import timedelta
 from timeit import default_timer
 from typing import Callable
 
-__all__ = ["LogCustomWarning", "TimedLog"]
-
-
-class LogCustomWarning:
-    """Context wrapper that temporarily redirects warnings to a logger."""
-
-    def __init__(
-        self,
-        logger: logging.Logger,
-        alt_message: str | None = None,
-        ignore: bool = True,
-    ):
-        """Instead of showing the warning through the :func:`warnings.warning`
-        machinery, write the message as warning to the provided logger.
-
-        Args:
-            logger (:obj:`logging.Logger`):
-                The logger instance to which the warning is redirected.
-            alt_message (:obj:`str`, optional):
-                Replace the original message text with this value instead.
-            ignore (:obj:`bool`, optional):
-                Do not show warning with :func:`warnings.warning` (the default).
-        """
-        self._logger = logger
-        self._message = alt_message
-        self._ignore = ignore
-
-    def _process_warning(self, message, category, filename, lineno, *args):
-        if not self._ignore:
-            self._old_showwarning(message, category, filename, lineno, *args)
-        if self._message is not None:
-            message = self._message
-        else:
-            message = f"{category.__name__}: {message}"
-        self._logger.warning(message)
-
-    def __enter__(self) -> TimedLog:
-        self._old_showwarning = warnings.showwarning
-        warnings.showwarning = self._process_warning
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
-        warnings.showwarning = self._old_showwarning
+__all__ = ["TimedLog"]
 
 
 class TimedLog:

--- a/src/yaw/correlation/corrfuncs.py
+++ b/src/yaw/correlation/corrfuncs.py
@@ -19,7 +19,7 @@ from yaw.catalogs import PatchLinkage
 from yaw.config import OPTIONS, ResamplingConfig
 from yaw.core.abc import BinnedQuantity, HDFSerializable, PatchedQuantity
 from yaw.core.containers import Indexer, SampledData
-from yaw.core.logging import LogCustomWarning, TimedLog
+from yaw.core.logging import TimedLog
 from yaw.core.utils import TypePathStr
 from yaw.core.utils import format_float_fixed_width as fmt_num
 from yaw.correlation.estimators import (
@@ -106,10 +106,7 @@ class CorrData(SampledData):
     """Optional descriptive text for the contained data."""
 
     def __post_init__(self) -> None:
-        with LogCustomWarning(
-            logger, "invalid values encountered in correlation samples"
-        ):
-            super().__post_init__()
+        super().__post_init__()
 
     @classmethod
     def from_files(cls: Type[_Tdata], path_prefix: TypePathStr) -> _Tdata:

--- a/src/yaw/correlation/estimators.py
+++ b/src/yaw/correlation/estimators.py
@@ -22,7 +22,7 @@ True
 
 from __future__ import annotations
 
-import logging
+import warnings
 from abc import ABC, abstractclassmethod, abstractproperty
 from typing import TYPE_CHECKING
 
@@ -38,9 +38,6 @@ __all__ = [
     "Hamilton",
     "LandySzalay",
 ]
-
-
-logger = logging.getLogger(__name__)
 
 
 class EstimatorError(Exception):
@@ -159,7 +156,7 @@ class CorrelationEstimator(ABC):
     def _warn_enum_zero(cls, counts: NDArray):
         """Raise a warning if any value in the expression enumerator is zero"""
         if np.any(counts == 0.0):
-            logger.warning(f"estimator {cls.short} encontered zeros in enumerator")
+            warnings.warn(f"estimator {cls.short} encontered zeros in enumerator")
 
     @abstractclassmethod
     def eval(

--- a/src/yaw/correlation/estimators.py
+++ b/src/yaw/correlation/estimators.py
@@ -166,7 +166,7 @@ class CorrelationEstimator(ABC):
 
         Should call :meth:`_warn_enum_zero` to raise warnings on zero-division.
         """
-        NotImplemented
+        pass
 
 
 class PeeblesHauser(CorrelationEstimator):

--- a/src/yaw/correlation/paircounts.py
+++ b/src/yaw/correlation/paircounts.py
@@ -13,7 +13,6 @@ counts-to-total-objects and samples thereof.
 
 from __future__ import annotations
 
-import logging
 from abc import abstractmethod
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
@@ -38,7 +37,6 @@ from yaw.core.abc import (
     concatenate_bin_edges,
 )
 from yaw.core.containers import Indexer, PatchIDs, SampledData
-from yaw.core.logging import LogCustomWarning
 from yaw.core.math import apply_slice_ndim, outer_triu_sum
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -46,9 +44,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from pandas import IntervalIndex
 
 __all__ = ["PatchedTotal", "PatchedCount", "NormalisedCounts"]
-
-
-logger = logging.getLogger(__name__)
 
 _compression = dict(fletcher32=True, compression="gzip", shuffle=True)
 """default compression settings for :obj:`h5py.Dataset`."""
@@ -1038,15 +1033,12 @@ class NormalisedCounts(PatchedQuantity, BinnedQuantity, HDFSerializable):
         """
         counts = self.count.sample_sum(config)
         totals = self.total.sample_sum(config)
-        with LogCustomWarning(
-            logger, "some patches contain no data after binning by redshift"
-        ):
-            samples = SampledData(
-                binning=self.get_binning(),
-                data=(counts.data / totals.data),
-                samples=(counts.samples / totals.samples),
-                method=config.method,
-            )
+        samples = SampledData(
+            binning=self.get_binning(),
+            data=(counts.data / totals.data),
+            samples=(counts.samples / totals.samples),
+            method=config.method,
+        )
         return samples
 
     @classmethod

--- a/src/yaw/correlation/paircounts.py
+++ b/src/yaw/correlation/paircounts.py
@@ -161,12 +161,12 @@ class PatchedArray(BinnedQuantity, PatchedQuantity, HDFSerializable):
 
         The array 3-dimensional with shape (N, N, K), where N is the number of
         spatial patches, and K is the number of redshift bins."""
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def _sum(self, config: ResamplingConfig) -> NDArray:
         """Method that implements the sum over all patches."""
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def _jackknife(self, config: ResamplingConfig, signal: NDArray) -> NDArray:
@@ -175,7 +175,7 @@ class PatchedArray(BinnedQuantity, PatchedQuantity, HDFSerializable):
 
         For N patches, draw N realisations by leaving out one of the N patches.
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def _bootstrap(self, config: ResamplingConfig) -> NDArray:
@@ -185,7 +185,7 @@ class PatchedArray(BinnedQuantity, PatchedQuantity, HDFSerializable):
         For N patches, draw M realisations each containing N randomly chosen
         patches.
         """
-        raise NotImplementedError
+        pass
 
     @deprecated(reason="renamed to CorrFunc.sample_sum", version="2.3.1")
     def get_sum(self, *args, **kwargs):

--- a/src/yaw/redshifts.py
+++ b/src/yaw/redshifts.py
@@ -17,7 +17,6 @@ known.
 from __future__ import annotations
 
 import logging
-import warnings
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -28,7 +27,7 @@ from deprecated import deprecated
 
 from yaw.config import ResamplingConfig
 from yaw.core.containers import SampledValue
-from yaw.core.logging import LogCustomWarning, TimedLog
+from yaw.core.logging import TimedLog
 from yaw.core.math import rebin, shift_histogram
 from yaw.core.utils import TypePathStr
 from yaw.correlation import CorrData
@@ -205,13 +204,8 @@ class RedshiftData(CorrData):
         N = cross_data.n_samples
         dzsq_data = cross_data.dz**2
         dzsq_samp = np.tile(dzsq_data, N).reshape((N, -1))
-        with LogCustomWarning(
-            logger, "invalid values encountered in redshift estimate"
-        ):
-            nz_data = w_sp_data / np.sqrt(dzsq_data * w_ss_data * w_pp_data)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            nz_samp = w_sp_samp / np.sqrt(dzsq_samp * w_ss_samp * w_pp_samp)
+        nz_data = w_sp_data / np.sqrt(dzsq_data * w_ss_data * w_pp_data)
+        nz_samp = w_sp_samp / np.sqrt(dzsq_samp * w_ss_samp * w_pp_samp)
         return cls(
             binning=cross_data.binning,
             data=nz_data,

--- a/tests/yaw/config/test_backend.py
+++ b/tests/yaw/config/test_backend.py
@@ -1,0 +1,17 @@
+import os
+
+from pytest import raises
+
+from yaw.config import BackendConfig
+
+
+class TestBackendConfig:
+    def test_default_threads(self):
+        assert BackendConfig().thread_num == os.cpu_count()
+
+    def test_get_threads(self):
+        conf = BackendConfig(thread_num=10)
+        assert conf.get_threads() == 10
+        assert conf.get_threads(max=2) == 2
+        with raises(ValueError):
+            conf.get_threads(0)

--- a/tests/yaw/config/test_binning.py
+++ b/tests/yaw/config/test_binning.py
@@ -1,0 +1,111 @@
+import numpy as np
+import numpy.testing as npt
+from pytest import fixture, raises
+
+from yaw.config.binning import (
+    AutoBinningConfig,
+    ManualBinningConfig,
+    make_binning_config,
+)
+from yaw.config.utils import ConfigError
+
+
+@fixture
+def bin_edges():
+    return np.array([0.1, 0.2, 0.3])
+
+
+@fixture
+def bin_props(bin_edges):
+    props = dict(
+        zmin=bin_edges.min(),
+        zmax=bin_edges.max(),
+        zbin_num=len(bin_edges) - 1,
+        method="linear",
+    )
+    return props
+
+
+@fixture
+def manual_binning(bin_edges):
+    return ManualBinningConfig(bin_edges)
+
+
+@fixture
+def auto_binning(bin_props):
+    return AutoBinningConfig.generate(**bin_props)
+
+
+class TestManualBinningConfig:
+    def test_init(self, bin_edges, manual_binning):
+        npt.assert_array_equal(bin_edges, manual_binning.zbins)
+        assert manual_binning.method == "manual"
+        with raises(ValueError):
+            ManualBinningConfig(bin_edges[::-1])
+
+    def test_properties(self, bin_props, manual_binning):
+        assert manual_binning.zmin == bin_props["zmin"]
+        assert manual_binning.zmax == bin_props["zmax"]
+        assert manual_binning.zbin_num == bin_props["zbin_num"]
+
+    def test_to_dict(self, bin_edges, manual_binning):
+        the_dict = manual_binning.to_dict()
+        assert set(the_dict.keys()) == {"zbins", "method"}
+        npt.assert_array_equal(the_dict["zbins"], bin_edges)
+
+    def test_from_dict(self, bin_edges, manual_binning):
+        the_dict = dict(zbins=bin_edges)
+        assert ManualBinningConfig.from_dict(the_dict) == manual_binning
+        # provide arugments only consumed by AutoBinningConfig
+        the_dict.update(dict(zmin=bin_edges.min(), zmax=bin_edges.max()))
+        with raises(TypeError):
+            ManualBinningConfig.from_dict(the_dict)
+
+
+class TestAutoBinningConfig:
+    def test_generate(self, bin_edges, auto_binning):
+        method = "linear"
+        binning = AutoBinningConfig(bin_edges, method=method)
+        npt.assert_array_equal(bin_edges, binning.zbins)
+        assert binning.method == method
+        npt.assert_array_equal(bin_edges, auto_binning.zbins)
+
+    def test_properties(self, bin_props, auto_binning):
+        assert auto_binning.zmin == bin_props["zmin"]
+        assert auto_binning.zmax == bin_props["zmax"]
+        assert auto_binning.zbin_num == bin_props["zbin_num"]
+
+    def test_to_dict(self, auto_binning):
+        the_dict = auto_binning.to_dict()
+        assert set(the_dict.keys()) == {"zmin", "zmax", "zbin_num", "method"}
+
+    def test_from_dict(self, bin_props, auto_binning):
+        the_dict = {key: val for key, val in bin_props.items()}
+        assert AutoBinningConfig.from_dict(the_dict) == auto_binning
+        # provide arugments only consumed by ManualBinningConfig
+        the_dict.update(dict(zbins=bin_edges))
+        with raises(TypeError):
+            AutoBinningConfig.from_dict(the_dict)
+
+
+def test_make_binning_config_auto(bin_props, auto_binning):
+    assert auto_binning == make_binning_config(**bin_props)
+
+
+def test_make_binning_config_manual(bin_edges, manual_binning):
+    assert manual_binning == make_binning_config(zbins=bin_edges)
+
+
+def test_make_binning_config_all_arg(bin_edges, bin_props, manual_binning):
+    assert isinstance(
+        make_binning_config(zbins=bin_edges, **bin_props), AutoBinningConfig
+    )
+
+
+def test_make_binning_config_no_z_arg(bin_edges, bin_props, auto_binning):
+    with raises(ConfigError):
+        make_binning_config(zmin=0.1)
+    with raises(ConfigError):
+        make_binning_config(zmax=0.1)
+    with raises(ConfigError):
+        make_binning_config()

--- a/tests/yaw/config/test_binning.py
+++ b/tests/yaw/config/test_binning.py
@@ -45,6 +45,9 @@ class TestManualBinningConfig:
         with raises(ConfigError):
             ManualBinningConfig([0.1])
 
+    def test_pass_repr(self, manual_binning):
+        str(manual_binning)
+
     def test_eq(self, bin_edges, manual_binning):
         new_bins = bin_edges.copy()
         new_bins[-1] = 2.0
@@ -77,6 +80,9 @@ class TestAutoBinningConfig:
         npt.assert_array_equal(bin_edges, binning.zbins)
         assert binning.method == method
         npt.assert_array_equal(bin_edges, auto_binning.zbins)
+
+    def test_pass_repr(self, auto_binning):
+        str(auto_binning)
 
     def test_eq(self, bin_props, auto_binning):
         assert AutoBinningConfig.generate(**bin_props) == auto_binning

--- a/tests/yaw/config/test_configuration.py
+++ b/tests/yaw/config/test_configuration.py
@@ -1,0 +1,307 @@
+import numpy as np
+import numpy.testing as npt
+from astropy.cosmology import WMAP9, Planck15
+from pytest import fixture, mark, raises
+
+from yaw.config import (
+    AutoBinningConfig,
+    BackendConfig,
+    Configuration,
+    ManualBinningConfig,
+)
+from yaw.config.utils import ConfigError
+from yaw.core.cosmology import get_default_cosmology
+
+
+@fixture
+def default_kwargs():
+    return dict(rmin=10.0, rmax=100.0, zmin=0.1, zmax=0.3)
+
+
+@fixture
+def default_config(default_kwargs):
+    return Configuration.create(**default_kwargs)
+
+
+@fixture
+def default_dict(default_config):
+    return default_config.to_dict()
+
+
+@fixture
+def flat_dict(default_dict):
+    flat_dict = dict(cosmology=default_dict["cosmology"])
+    flat_dict.update(default_dict["scales"])
+    flat_dict.update(default_dict["binning"])
+    flat_dict.update(default_dict["backend"])
+    return flat_dict
+
+
+@fixture
+def manual_config(default_kwargs):
+    kwargs = dict(
+        rmin=default_kwargs["rmin"],
+        rmax=default_kwargs["rmax"],
+        zbins=np.array([0.1, 0.3, 0.5]),
+    )
+    return Configuration.create(**kwargs)
+
+
+class TestConfigurationCreate:
+    def test_default(self, default_config, default_kwargs):
+        assert default_config.cosmology is get_default_cosmology()
+        assert default_config.scales.rmin == default_kwargs["rmin"]
+        assert default_config.scales.rmax == default_kwargs["rmax"]
+        assert default_config.binning.zmin == default_kwargs["zmin"]
+        assert default_config.binning.zmax == default_kwargs["zmax"]
+
+    def test_no_rmin(self):
+        kwargs = dict(rmax=100.0, zmin=0.1, zmax=0.3)
+        with raises(TypeError):
+            Configuration.create(**kwargs)
+
+    def test_no_zmin(self):
+        kwargs = dict(rmin=10.0, rmax=100.0, zmax=0.3)
+        with raises(ConfigError):
+            Configuration.create(**kwargs)
+
+    def test_cosmo_parsing(self):
+        kwargs = dict(cosmology="Planck15", rmin=10.0, rmax=100.0, zmin=0.1, zmax=0.3)
+        conf = Configuration.create(**kwargs)
+        assert conf.cosmology is Planck15
+        assert conf.cosmology is not WMAP9
+
+    def test_zbins(self):
+        bins = np.array([0.1, 0.3, 0.5])
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zbins=bins,
+        )
+        conf = Configuration.create(**kwargs)
+        npt.assert_array_equal(conf.binning.zbins, bins)
+
+    def test_zbins_zmin_none(self):
+        bins = np.array([0.1, 0.3, 0.5])
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zbins=bins,
+            zmin=None,
+        )
+        conf = Configuration.create(**kwargs)
+        npt.assert_array_equal(conf.binning.zbins, bins)
+
+    def test_zbins_method_none(self):
+        bins = np.array([0.1, 0.3, 0.5])
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zbins=bins,
+            method=None,
+        )
+        conf = Configuration.create(**kwargs)
+        npt.assert_array_equal(conf.binning.zbins, bins)
+
+    def test_autoz_zbins_none(self):
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zmin=0.1,
+            zmax=0.3,
+            zbins=None,
+        )
+        assert Configuration.create(**kwargs).binning.zmin == 0.1
+
+    def test_autoz_linear(self):
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zmin=0.1,
+            zmax=0.3,
+            zbin_num=2,
+            method="linear",
+        )
+        conf = Configuration.create(**kwargs)
+        assert conf.binning.method == "linear"
+        assert conf.binning.zbins[1] == 0.2
+
+    def test_autoz_comoving(self):
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zmin=0.1,
+            zmax=0.3,
+            zbin_num=2,
+            method="comoving",
+        )
+        conf = Configuration.create(**kwargs)
+        assert conf.binning.method == "comoving"
+        assert conf.binning.zbins[1] != 0.2
+
+    def test_zbin_num(self):
+        kwargs = dict(
+            rmin=10.0,
+            rmax=100.0,
+            zmin=0.1,
+            zmax=0.3,
+            zbin_num=10,
+        )
+        assert len(Configuration.create(**kwargs).binning.zbins) == 11
+
+
+class TestConfigurationModify:
+    def test_copy(self, default_config):
+        assert default_config.modify() == default_config
+
+    def test_parse_cosmology(self, default_config):
+        assert default_config.modify(cosmology="WMAP9").cosmology == WMAP9
+        assert default_config.modify(cosmology=WMAP9).cosmology == WMAP9
+
+    def test_update_scales(self, default_config):
+        substitutes = dict(
+            rmin=20.0,
+            rmax=200.0,
+            rweight=1.0,
+            rbin_num=10,
+        )
+        for param, value in substitutes.items():
+            conf = default_config.modify(**{param: value})
+            assert getattr(conf.scales, param) == value
+
+    def test_update_binning_auto_update_zbins(self, default_config, manual_config):
+        zbins = manual_config.binning.zbins
+        assert default_config.modify(zbins=zbins).binning == manual_config.binning
+
+    def test_update_binning_auto_update_other(self, default_config):
+        auto_config: Configuration = default_config.modify()
+        auto_substitutes = dict(
+            zmin=0.001,
+            zmax=10.0,
+            zbin_num=5,
+            method="comoving",
+        )
+        for param, value in auto_substitutes.items():
+            conf = auto_config.modify(**{param: value})
+            auto_kwargs = auto_config.to_dict()["binning"]
+            auto_kwargs[param] = value
+            assert conf.binning == AutoBinningConfig.generate(**auto_kwargs)
+
+    def test_update_binning_manual_update_zbins(self, manual_config):
+        zbins = np.linspace(1, 10)
+        assert manual_config.modify(zbins=zbins).binning == ManualBinningConfig(zbins)
+
+    def test_update_binning_manual_all_other(self, manual_config, default_dict):
+        bin_dict = default_dict["binning"]
+        kwargs = dict(zmin=bin_dict["zmin"], zmax=bin_dict["zmax"])
+        # only z limits
+        expect = AutoBinningConfig.generate(**bin_dict)
+        got = manual_config.modify(**kwargs)
+        assert expect == got.binning
+        # add method
+        added_dict = {k: v for k, v in bin_dict.items() if k != "method"}
+        expect = AutoBinningConfig.generate(**added_dict, method="comoving")
+        got = manual_config.modify(**kwargs, method="comoving")
+        assert expect == got.binning
+        # add zbin_num
+        added_dict = {k: v for k, v in bin_dict.items() if k != "zbin_num"}
+        expect = AutoBinningConfig.generate(**added_dict, zbin_num=5)
+        got = manual_config.modify(**kwargs, zbin_num=5)
+        assert expect == got.binning
+
+    @mark.parametrize("param", ["zmin", "zmax"])
+    def test_update_binning_manual_some_other(self, manual_config, param):
+        with raises(ConfigError):
+            manual_config.modify(**{param: 0.1})
+
+    def test_update_backend(self, default_config):
+        substitutes = dict(
+            thread_num=100,
+            crosspatch=False,
+            rbin_slop=10.0,
+        )
+        for param, value in substitutes.items():
+            conf = default_config.modify(**{param: value})
+            assert getattr(conf.backend, param) == value
+
+    def test_update_cosmology(self, default_config):
+        assert default_config.modify(cosmology=WMAP9).cosmology == WMAP9
+
+
+class TestConfiguration:
+    def test_parse_cosmology(self, default_config):
+        conf = Configuration(
+            scales=default_config.scales,
+            binning=default_config.scales,
+            backend=default_config.backend,
+            cosmology=None,
+        )
+        assert conf.cosmology == get_default_cosmology()
+        conf = Configuration(
+            scales=default_config.scales,
+            binning=default_config.scales,
+            backend=default_config.backend,
+        )
+        assert conf.cosmology == get_default_cosmology()
+        with raises(ConfigError):
+            Configuration(
+                scales=default_config.scales,
+                binning=default_config.scales,
+                backend=default_config.backend,
+                cosmology=1,
+            )
+
+    def test_from_dict(self, default_dict, flat_dict):
+        # make sure that .create and .from_dict produce the same results
+        created = Configuration.create(**flat_dict)
+        restored = Configuration.from_dict(default_dict)
+        assert created == restored
+
+    def test_from_dict_missing_sections(self, default_dict):
+        sca = default_dict["scales"]
+        bng = default_dict["binning"]
+        bck = default_dict["backend"]
+        # drop cosmology
+        conf = Configuration.from_dict(dict(scales=sca, binning=bng, backend=bck))
+        assert conf.cosmology == get_default_cosmology()
+        # drop scales
+        with raises(ConfigError, match="scales"):
+            Configuration.from_dict(dict(binning=bng, backend=bck))
+        # drop binning
+        with raises(ConfigError, match="binning"):
+            Configuration.from_dict(dict(scales=sca, backend=bck))
+        # drop backend
+        conf = Configuration.from_dict(dict(scales=sca, binning=bng))
+        assert conf.backend == BackendConfig()
+
+    @mark.parametrize("section", ["scales", "binning", "backend"])
+    def test_from_dict_extra_item(self, default_dict, section):
+        extra_dict = {k: v for k, v in default_dict.items()}
+        extra_dict[section]["extra_key"] = None
+        with raises(ConfigError, match="unknown option"):
+            Configuration.from_dict(extra_dict)
+
+    @mark.parametrize(
+        "section,item",
+        [
+            ("scales", "rmin"),
+            ("scales", "rmax"),
+        ],
+    )
+    def test_from_dict_missing_item(self, default_dict, section, item):
+        miss_dict = {k: v for k, v in default_dict.items()}
+        miss_dict[section].pop(item)
+        with raises(ConfigError, match="missing option"):
+            Configuration.from_dict(miss_dict)
+
+    def test_from_dict_extra_section(self, default_dict):
+        the_dict = {k: v for k, v in default_dict.items()}
+        the_dict["extra_section"] = dict()
+        with raises(ConfigError, match="unknown section"):
+            Configuration.from_dict(the_dict)
+
+    def test_yaml(self, default_config, tmp_path):
+        # implicitly tests that .to_dict -> .from_dict is consistent
+        f = tmp_path / "config_dump.yaml"
+        default_config.to_yaml(f)
+        assert default_config == Configuration.from_yaml(f)

--- a/tests/yaw/config/test_not_set.py
+++ b/tests/yaw/config/test_not_set.py
@@ -1,0 +1,8 @@
+from yaw.config.default import NotSet
+
+
+class TestNotSet:
+    def test_is_false(self):
+        assert bool(NotSet) is False
+        if NotSet:
+            assert 0

--- a/tests/yaw/config/test_options.py
+++ b/tests/yaw/config/test_options.py
@@ -1,0 +1,12 @@
+from pytest import mark
+
+from yaw.config import OPTIONS
+
+
+class TestOptions:
+    @mark.parametrize(
+        "parameter", ["backend", "binning", "cosmology", "kind", "merge", "method"]
+    )
+    def test_properties_are_tuple(self, parameter):
+        option_values = getattr(OPTIONS, parameter)
+        assert isinstance(option_values, tuple)

--- a/tests/yaw/config/test_resampling.py
+++ b/tests/yaw/config/test_resampling.py
@@ -1,0 +1,53 @@
+import numpy as np
+import numpy.testing as npt
+from pytest import mark, raises
+
+from yaw.config import OPTIONS, ResamplingConfig
+from yaw.config.utils import ConfigError
+
+
+class TestResamplingConfig:
+    def test_init(self):
+        with raises(ConfigError):
+            ResamplingConfig(method="my undefined method")
+
+    @mark.parametrize("method", OPTIONS.method)
+    def test_n_patches(self, method):
+        conf = ResamplingConfig(method=method)
+        assert conf.n_patches is None
+        n_patches = 10
+        conf.get_samples(n_patches)
+        assert conf.n_patches == n_patches
+
+    def test__generate_jackknife(self):
+        samples = ResamplingConfig()._generate_jackknife(n_patches=3)
+        npt.assert_array_equal(samples.sum(axis=1), [3, 2, 1])
+
+    def test__generate_bootstrap(self):
+        conf = ResamplingConfig(method="bootstrap", seed=12345, n_boot=10)
+        samples = conf._generate_bootstrap(n_patches=3)
+        expect = np.array([4, 2, 5, 3, 2, 2, 5, 4, 4, 1])
+        npt.assert_array_equal(samples.sum(axis=1), expect)
+
+    def test_get_samples(self):
+        # tested sampling methods above
+        conf = ResamplingConfig()
+        conf.get_samples(n_patches=3)
+        with raises(ValueError):
+            conf.get_samples(4)
+
+    def test_reset(self):
+        conf = ResamplingConfig()
+        conf.get_samples(n_patches=3)
+        conf.reset()
+        assert conf._resampling_idx is None
+
+        kwargs = dict(method="jackknife", crosspatch=False, global_norm=True)
+        conf = ResamplingConfig(**kwargs)
+        assert ResamplingConfig.from_dict(conf.to_dict()) == conf
+
+        kwargs = dict(
+            method="bootstrap", crosspatch=False, n_boot=10, global_norm=True, seed=321
+        )
+        conf = ResamplingConfig(**kwargs)
+        assert ResamplingConfig.from_dict(conf.to_dict()) == conf

--- a/tests/yaw/config/test_scales.py
+++ b/tests/yaw/config/test_scales.py
@@ -1,0 +1,47 @@
+import numpy as np
+from pytest import fixture, raises
+
+from yaw.config import ScalesConfig
+from yaw.config.utils import ConfigError
+from yaw.core.cosmology import Scale
+
+
+@fixture
+def default_scales():
+    return ScalesConfig(np.array([100, 200]), np.array([1000, 2000]))
+
+
+class TestScalesConfig:
+    def test_init_scalar(self):
+        with raises(ConfigError):
+            ScalesConfig(100, 100)
+
+    def test_init_array(self, default_scales):
+        with raises(ConfigError):
+            ScalesConfig([100], [1000, 2000])
+        with raises(ConfigError):
+            ScalesConfig([100, 2000], [1000, 200])
+        assert isinstance(default_scales.rmin, list)
+        assert isinstance(default_scales.rmax, list)
+        conf = ScalesConfig(np.array([100]), np.array([1000]))
+        assert isinstance(conf.rmin, float)
+        assert isinstance(conf.rmax, float)
+
+    def test_init_mixed(self):
+        with raises(ConfigError):
+            ScalesConfig(100, [100])
+
+    def test_dict_keys(self, default_scales):
+        scales = set(default_scales.dict_keys())
+        assert scales == set(str(scale) for scale in default_scales)
+
+    def test_getitem(self, default_scales):
+        assert default_scales[1] == Scale(
+            default_scales.rmin[1], default_scales.rmax[1]
+        )
+
+    def test_eq(self, default_scales):
+        scales = default_scales
+        assert scales != ScalesConfig(scales.rmin[:1], scales.rmax[:1])
+        assert scales != ScalesConfig(scales.rmin, scales.rmax, rweight=1.0)
+        assert scales != ScalesConfig(scales.rmin, scales.rmax, rbin_num=11)

--- a/tests/yaw/config/test_utils.py
+++ b/tests/yaw/config/test_utils.py
@@ -1,5 +1,5 @@
 from astropy.cosmology import FlatwCDM, Planck15
-from pytest import raises
+from pytest import mark, raises
 
 from yaw.config import utils
 from yaw.core.cosmology import CustomCosmology, get_default_cosmology
@@ -37,3 +37,20 @@ def test_parse_cosmology():
     with raises(utils.ConfigError):
         utils.parse_cosmology(123)
     assert utils.parse_cosmology(Planck15) == Planck15
+
+
+@mark.parametrize("exception", [KeyError, TypeError])
+def test_parse_section_error_propagates_unknown(exception):
+    with raises(exception):
+        try:
+            raise exception
+        except Exception as e:
+            utils.parse_section_error(e, "some_section")
+
+
+def test_parse_section_error_propagates_other_typeerror():
+    with raises(TypeError):
+        try:
+            raise TypeError("some error")
+        except Exception as e:
+            utils.parse_section_error(e, "some_section")

--- a/tests/yaw/config/test_utils.py
+++ b/tests/yaw/config/test_utils.py
@@ -1,0 +1,39 @@
+from astropy.cosmology import FlatwCDM, Planck15
+from pytest import raises
+
+from yaw.config import utils
+from yaw.core.cosmology import CustomCosmology, get_default_cosmology
+
+
+class DummyCosmo(CustomCosmology):
+    def comoving_distance(self, z):
+        return 1.0
+
+    def comoving_transverse_distance(self, z):
+        return 1.0
+
+
+def test_cosmology_to_yaml():
+    with raises(TypeError):
+        utils.cosmology_to_yaml(1)
+    with raises(utils.ConfigError):
+        utils.cosmology_to_yaml(DummyCosmo())
+    with raises(utils.ConfigError):
+        utils.cosmology_to_yaml(FlatwCDM(70, 0.3))
+    assert utils.cosmology_to_yaml(Planck15) == Planck15.name
+
+
+def test_yaml_to_cosmology():
+    with raises(utils.ConfigError):
+        utils.yaml_to_cosmology("my undefined cosmolgy")
+    assert utils.yaml_to_cosmology(Planck15.name) == Planck15
+
+
+def test_parse_cosmology():
+    assert utils.parse_cosmology(None) == get_default_cosmology()
+    assert utils.parse_cosmology(Planck15.name) == Planck15
+    with raises(utils.ConfigError):
+        utils.parse_cosmology("my undefined cosmolgy")
+    with raises(utils.ConfigError):
+        utils.parse_cosmology(123)
+    assert utils.parse_cosmology(Planck15) == Planck15

--- a/tests/yaw/core/test_cosmology.py
+++ b/tests/yaw/core/test_cosmology.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 from astropy.cosmology import Planck15
-from pytest import mark
+from pytest import raises
 
 from yaw.core import cosmology
 
@@ -20,23 +20,55 @@ def test_r_kpc_to_angle():
     npt.assert_almost_equal(result, require)
 
 
-class TestBinFactory:
-    @mark.skip
+class TestScale:
     def test_init(self):
-        pass
+        with raises(ValueError):
+            cosmology.Scale(10, 2)
 
-    @mark.skip
+    def test_mid(self):
+        assert cosmology.Scale(10.0, 30.0).mid == 20.0
+
+    def test_mid_log(self):
+        assert cosmology.Scale(1.0, 100.0).mid_log == 10.0
+
+    def test_to_radian(self):
+        cosmo = cosmology.get_default_cosmology()
+        z = 5.0
+        npt.assert_array_equal(
+            cosmology.Scale(500.0, 5000.0).to_radian(z, cosmo),
+            cosmology.r_kpc_to_angle([500.0, 5000.0], z, cosmo),
+        )
+
+
+class TestBinFactory:
+    def test_init(self):
+        nbins = 30
+        with raises(ValueError):
+            cosmology.BinFactory(0.4, 0.1, nbins)
+        assert (
+            cosmology.BinFactory(0.1, 0.2, nbins).cosmology
+            == cosmology.get_default_cosmology()
+        )
+
     def test_linear(self):
-        pass  # include .get()
+        result = [1, 2, 3]
+        factory = cosmology.BinFactory(1, 3, nbins=2)
+        npt.assert_array_equal(factory.linear(), result)
+        npt.assert_array_equal(factory.get("linear"), result)
 
-    @mark.skip
     def test_comoving(self):
-        pass  # include .get()
+        result = np.array([0.1, 0.1972829, 0.3])  # from previous run
+        factory = cosmology.BinFactory(0.1, 0.3, nbins=2)
+        npt.assert_almost_equal(factory.comoving(), result)
+        npt.assert_almost_equal(factory.get("comoving"), result)
 
-    @mark.skip
     def test_logspace(self):
-        pass  # include .get()
+        result = np.exp([1, 2, 3]) - 1.0
+        factory = cosmology.BinFactory(result[0], result[-1], nbins=2)
+        npt.assert_array_equal(factory.logspace(), result)
+        npt.assert_array_equal(factory.get("logspace"), result)
 
-    @mark.skip
     def test_check(self):
-        pass
+        factory = cosmology.BinFactory(0.1, 0.2, nbins=9)
+        with raises(ValueError):
+            factory.get("my undefined method")


### PR DESCRIPTION
- Emit warnings instead of sending to the python logging interface where they might be unnoticed.
- Added unittest for ``yaw.core.config``.
- Added missing unittest for ``yaw.core.cosmology``.
- Deprecated the ``Configuration.plot_scales`` method.

Bug fixes
---------

- Added missing default values when creating binning configurations.
- Added missing checks for input parameters of configuration related classes.
- Made the behaviour of ``Configuration.modify`` for different binning related parameters consistent.
- Fixed the ``ResamplingConfig.n_patches`` return values.
- Corrected the parameters returned by ``ResamplingConfig.to_dict``.
- Various other minor bug fixes in ``yaw.core.config``.
